### PR TITLE
Fix state class of total consumption

### DIFF
--- a/custom_components/gen2_wallbox/sensor.py
+++ b/custom_components/gen2_wallbox/sensor.py
@@ -207,10 +207,10 @@ class WallBoxDeviceEnergy(SensorEntity):
     """Representation actual cumulative output in kWh."""
 
     _attr_has_entity_name = True
-    _attr_name = "Compsumption"
+    _attr_name = "Consumption"
     _attr_nonunique_id = "wallbox_compsumption"
     _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
 
     def __init__(self, data) -> None:


### PR DESCRIPTION
Hi,

thanks a lot for your work!

I've started using my wallbox and noticed a little problem. The "GEN2 Wallbox Compsumption" always resets back to 0 at the end of charging:

![image](https://github.com/jiristepan/hass-gen2-wallbox/assets/878801/4a96d29f-c744-4104-8f5c-4f8b378dd84e)

The problem is when I add it to the Energy panel as an individual device, it always ends up showing a value around 0 instead of, say, 13, because it subtracts the drop back to 0.

![image](https://github.com/jiristepan/hass-gen2-wallbox/assets/878801/193b167c-211c-42fe-921a-5b2ba1de1b01)

Based on [documentation](https://developers.home-assistant.io/docs/core/entity/sensor#how-to-choose-state_class-and-last_reset), I propose changing entity type to "total_increasing" in this PR.
